### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Downloads](https://img.shields.io/npm/dm/fskeleton.svg?style=flat)](https://www.npmjs.com/package/fskeleton)
 [![Build Status](https://travis-ci.org/terox/skeleton.svg)](https://travis-ci.org/terox/skeleton)
 [![Code Climate](https://codeclimate.com/github/terox/skeleton/badges/gpa.svg)](https://codeclimate.com/github/terox/skeleton)
+[![Inline docs](http://inch-ci.org/github/terox/skeleton.svg?branch=master)](http://inch-ci.org/github/terox/skeleton)
 
 > Easy and fast library for generate file and folder structure in your
 > projects with a very small effort.


### PR DESCRIPTION
Hi there,

you have recently tried to evaluate this project via Inch. I took the liberty to make a badge for you: [![Inline docs](http://inch-ci.org/github/terox/skeleton.svg)](http://inch-ci.org/github/terox/skeleton)

The badge shows an evaluation by [InchJS](http://trivelop.de/inchjs), but I guess you already knew that. :wink: 

I would really like to roll out support for JS over the coming weeks (early adopters are [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [Shipit](https://github.com/shipitjs/shipit)).

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/terox/skeleton

What do you think?
